### PR TITLE
Sort blackList plugins to bottom

### DIFF
--- a/app/js/controller/pluginList.js
+++ b/app/js/controller/pluginList.js
@@ -13,7 +13,36 @@ angular.module('npm-plugin-browser')
             sort: 'rating:desc'
           }});
       },
-          initialFetchSize = 15;
+          initialFetchSize = 15,
+          sortBy = function () {
+            var args = arguments;
+
+            return function (a, b) {
+              var scoreA, scoreB;
+
+              for (var i = 0, len = args.length; i < len; i++) {
+                scoreA = args[i](a);
+                scoreB = args[i](b);
+                if (scoreA < scoreB) {
+                  return -1;
+                } else if (scoreA > scoreB) {
+                  return 1;
+                }
+              }
+
+              return 0;
+            };
+          },
+        sortResults = function (results) {
+          return results.sort(sortBy(
+            // Sort blackList plugins to bottom
+            function (plugin) { return blackList[plugin.name] ? 1 : 0; },
+            // Sort highly-rated plugins to top
+            function (plugin) { return -plugin.rating; }
+            // Fall back to sort by name
+            function (plugin) { return plugin.name; }
+          ));
+        };
 
       $scope.blackList = blackList;
 
@@ -21,14 +50,14 @@ angular.module('npm-plugin-browser')
       ngProgress.start();
       makeRequest(0, initialFetchSize)
           .then(function (response) {
-            $scope.data = response.data.results;
+            $scope.data = sortResults(response.data.results);
             return response.data.total;
           })
           .then(function (total) {
             return makeRequest(initialFetchSize, total);
           })
           .then(function (response) {
-            $scope.data =  $scope.data.concat(response.data.results);
+            $scope.data = sortResults($scope.data.concat(response.data.results));
           })
           .then(function(){
             if (angular.isString(($location.search()).q)) {


### PR DESCRIPTION
Stable sort of plugins based on inclusion in blackList.

blackList plugins always sort after non-blackList ones.
Plugins with equivalent blackList status sort on rating, with more-highly-rated plugins sorting before lower-rated ones.
