### PR TITLE
Remove gulp-concat-sourcemap plugin from blacklist

### DIFF
--- a/blackList.json
+++ b/blackList.json
@@ -53,6 +53,5 @@
   "gulp-jshint-cached": "duplicate of gulp-jshint",
   "gulp-twitter": "not a gulp plugin",
   "gulp-print": "duplicate of gulp-debug",
-  "gulp-rev-all": "duplicate of gulp-rev",
-  "gulp-concat-sourcemap": "duplicate of gulp-concat"
+  "gulp-rev-all": "duplicate of gulp-rev"
 }


### PR DESCRIPTION
`gulp-concat-sourcemap` is not duplicate of `gulp-concat`.
`gulp-concat` can be used to concat all types of files.
`gulp-concat-sourcemap` is used to concat `.js` and `.css` files that need to have sourcemaps.

This functionality may be useful for everyone who wants to be able to debug resulting JS and CSS, and `gulp-concat` doesn't have such abilities. Corresponding issue was opened in wearefractal/gulp-concat#27 but it's not likely this functionality will be merged, so let's leave this plugin separately at least until any decision about merging will be made.
