### PR TITLE
Removed gulp-ember-handlebars from the list

### DIFF
--- a/app/assets/blackList.json
+++ b/app/assets/blackList.json
@@ -14,7 +14,6 @@
   "gulp-connect": "use the connect module directly",
   "gulp-image-optimization": "duplicate of gulp-imagemin",
   "gulp-bower": "use the bower module directly",
-  "gulp-ember-handlebars": "duplicate of gulp-handlebars & too complex",
   "gulp-handlebars-michael": "duplicate of gulp-handlebars",
   "gulpify": "deprecated - use vinyl-source-stream instead",
   "gulp-web-modules": "a grab bag of tasks/plugins - not a plugin itself",


### PR DESCRIPTION
Hi,

I've read all that's been said [here](https://github.com/fuseelements/gulp-ember-handlebars/issues/2), in the `gulp-ember-handlebars` repo and also elsewhere, and I do think that blacklisting this plugin by just stating that it's a "duplicate of gulp-handlebars" isn't really telling the whole picture.

At the moment, there is really no alternative (at least that I know of) for those of us who use gulp to precompile Ember Handlebars templates. I do therefore feel that blacklisting it is a bit unwarranted.

Yes, in the future, it might be that we don't really need this plugin if gulp-handlebars is extended to support a custom compiler (to use e.g. `ember-template-compiler`) but until that has happened, please don't blacklist a module that is really useful to some of us.
