### PR TITLE
Add gulp-tinypng to the blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -64,5 +64,6 @@
   "gulp-commonjs": "no (github-)repository available, use gulp-wrap-commonjs",
   "gulp-regex-replace": "duplicate of gulp-replace",
   "gulp-license-finder": "shouldn't be a gulp plugin",
-  "gulp-common-wrap": "No README, No (github-)repository - use gulp-wrap-commonjs instead"
+  "gulp-common-wrap": "No README, No (github-)repository - use gulp-wrap-commonjs instead",
+  "gulp-tinypng": "uses fs to create a temp .gulp folder"
 }


### PR DESCRIPTION
gulp-tinypng uses fs to create a temp .gulp folder
