### PR TITLE
Update blackList.json

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -65,5 +65,6 @@
   "gulp-regex-replace": "duplicate of gulp-replace",
   "gulp-license-finder": "shouldn't be a gulp plugin",
   "gulp-common-wrap": "No README, No (github-)repository - use gulp-wrap-commonjs instead",
-  "gulp-tinypng": "uses fs to create a temp .gulp folder"
+  "gulp-tinypng": "uses fs to create a temp .gulp folder",
+  "gulp-static-site": "duplicate of gulp-jade"
 }


### PR DESCRIPTION
`gulp-static-site` is a duplicate of `gulp-jade`
https://github.com/0x01/gulp-static-site
- No tests
- Requires gulp
