### PR TITLE
Add gulp-tag-version to the blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -65,5 +65,6 @@
   "gulp-common-wrap": "No README, No (github-)repository - use gulp-wrap-commonjs instead",
   "gulp-tinypng": "uses fs to create a temp .gulp folder",
   "gulp-static-site": "duplicate of gulp-jade",
-  "gulp-faster-browserify": "use the watchify module directly: https://github.com/gulpjs/gulp/blob/master/docs/recipes/fast-browserify-builds-with-watchify.md"
+  "gulp-faster-browserify": "use the watchify module directly: https://github.com/gulpjs/gulp/blob/master/docs/recipes/fast-browserify-builds-with-watchify.md",
+  "gulp-tag-version": "should not be a gulp plugin - uses other gulp plugins"
 }


### PR DESCRIPTION
`gulp-tag-version` uses other plugins to do a `git tag` and JSON version bump.
Uses `gulp-git` to tag, and then bumps the `version`.
