### PR TITLE
Fixing problem with some plugins showing up twice

### DIFF
--- a/src/scripts/controller/pluginList.js
+++ b/src/scripts/controller/pluginList.js
@@ -29,7 +29,7 @@ angular.module('npm-plugin-browser')
         params: {
           q: 'keywords:gulpplugin,gulpfriendly',
           fields: fields.join(','),
-          start: start,
+          from: start,
           size: size
         },
         transformResponse: $http.defaults.transformResponse.concat([formatData])


### PR DESCRIPTION
The limiting parameter for Elastic Search is named `"from"` instead of `"start"`. As it is now the first 15 hits is fetched twice, for instance `amd-optimize` shows up twice in the result list.

I had the same problem with the Slush generator search page, see [Slush #8](https://github.com/slushjs/slush/issues/8).

This pull request fixes that.
