### PR TITLE
Added favicon-generator (unpublished)

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -161,5 +161,6 @@
   "fd-gulp-chinese2unicode": "inaccessible repo",
   "fd-gulp-convert-encoding": "inaccessible repo",
   "fd-gulp-encodingfilter": "inaccessible repo",
-  "fd-gulp-styleversion": "inaccessible repo"
+  "fd-gulp-styleversion": "inaccessible repo",
+  "favicon-generator": "unpublished by author"
 }


### PR DESCRIPTION
"favicon-generator" has been unpublished. It has been republished as [favicons](https://www.npmjs.org/package/favicons) (I _think_ it's the same), but I don't know if it can still be considered "gulp friendly".
