### PR TITLE
Add gulp-tsc to the blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -167,5 +167,6 @@
   "gulp-remove-files": "operates directly on file paths",
   "gulp-update": "not a gulp plugin",
   "gulp-uncache": "works files from outside the stream",
-  "gulp-execsyncs": "synchronous. use gulp-exec instead"
+  "gulp-execsyncs": "synchronous. use gulp-exec instead",
+  "gulp-tsc": "operates directly on file paths. does too much."
 }


### PR DESCRIPTION
https://github.com/kotas/gulp-tsc
- [It directly passes file paths to the `tsc` command arguments.](https://github.com/kotas/gulp-tsc/blob/9a0d4f6a8535710a2d57dd72c9dae606b0821c06/lib/tsc.js#L14-L40)
- It does too much.
  - [options.pathFilter](https://github.com/kotas/gulp-tsc/tree/9a0d4f6a8535710a2d57dd72c9dae606b0821c06#optionspathfilter) -> [gulp-rename](https://github.com/hparra/gulp-rename)
  - [options.safe](https://github.com/kotas/gulp-tsc/tree/9a0d4f6a8535710a2d57dd72c9dae606b0821c06#optionssafe) -> [gulp-plumber](https://github.com/floatdrop/gulp-plumber)
