### PR TITLE
Update blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -168,5 +168,6 @@
   "gulp-update": "not a gulp plugin",
   "gulp-uncache": "works files from outside the stream",
   "gulp-execsyncs": "synchronous. use gulp-exec instead",
-  "gulp-tsc": "operates directly on file paths. does too much."
+  "gulp-tsc": "operates directly on file paths. does too much.",
+  "gulp-sketch": "operates directly on file paths. creates a folder outside the stream."
 }


### PR DESCRIPTION
[gulp-sketch](https://github.com/cognitom/gulp-sketch)
- [It directly passes files paths to the `sketchtool` command arguments.](https://github.com/cognitom/gulp-sketch/blob/2aa692af35c9228ee493b8dd06f0a244d19977da/coffee/index.coffee#L26-L37)
- [It creates a temporary directory outsude the stream.](https://github.com/cognitom/gulp-sketch/blob/2aa692af35c9228ee493b8dd06f0a244d19977da/coffee/index.coffee#L37)
