### PR TITLE
Add gulp-blink to blackList.json

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -1,4 +1,5 @@
 {
+  "gulp-blink": "use the `blink` module directly",
   "gulp-clean": "use the `del` module",
   "gulp-rimraf": "use the `del` module",
   "gulp-browserify": "use the browserify module directly",


### PR DESCRIPTION
The [blink](https://github.com/blinkjs/blink) module is now gulpfriendly.
