### PR TITLE
Fixed keyword link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
                     <div class="more-info">
                         <div class="tags">
                             <a ng-repeat="keyword in plugin.keywords | orderBy:orderByGulpKeywords track by $index"
-                               ng-href="http://npmsearch.com/?q={{keyword}}"
+                               ng-href="http://npmsearch.com/?q=keywords:{{keyword}}"
                                target="_blank"
                                ng-bind="keyword"></a>
                         </div>


### PR DESCRIPTION
When I click on keyword link, browser opens page with no search results (e.g. http://npmsearch.com/?q=gulpfriendly)
