### PR TITLE
Blacklist gulp-htmin

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -5,6 +5,7 @@
   "gulp-browserify": "use the browserify module directly",
   "gulp-requirejs": "use the require.js module directly",
   "gulp-myth-css": "duplicate of gulp-myth",
+  "gulp-htmin": "duplicate of gulp-htmlmin",
   "gulp-filesize": "duplicate of gulp-size",
   "gulp-redust": "duplicate of gulp-dust",
   "gulp-shell": "duplicate of gulp-exec",


### PR DESCRIPTION
I would like to have [this plugin](https://github.com/nmrugg/gulp-htmin) blacklisted. It's simply duplicate of `gulp-htmlmin`. The only things changed in the fork are the readme and the `package.json` file.
