### PR TITLE
Blacklist gulp-angular-templatecache-ionic

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -1,4 +1,5 @@
 {
+  "gulp-angular-templatecache-ionic": "duplicate of gulp-angular-templatecache",
   "gulp-blink": "deprecated. use `blink` instead.",
   "gulp-clean": "use the `del` module",
   "gulp-rimraf": "use the `del` module",


### PR DESCRIPTION
[This plugin](https://www.npmjs.org/package/gulp-angular-templatecache-ionic/) seems to be a duplicate of `gulp-angular-templatecache`, isn't it?

(Cc:  @adamshiervani)
