### PR TITLE
blacklist grunt-favicons-tasks

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -241,5 +241,6 @@
   "gulp-jsx": "duplicate of gulp-react",
   "gulp-unpathify": "use the `unpathify` module directly",
   "gulp-filter-by": "duplicate of gulp-filter",
-  "gulp-inline-source": "duplicate of gulp-smoosher"
+  "gulp-inline-source": "duplicate of gulp-smoosher",
+  "grunt-favicons-tasks": "use the `favicons` module directly"
 }


### PR DESCRIPTION
With this plugin you can't do anything more/easier than using the [`favicons` module](https://github.com/creunabo/favicons) directly.

[Also, this plugin seems to be grunt focussed](https://github.com/creunabo/favicons/commit/7152f6d328239bbfa4d4da923e18aee6b15a7d3a).

Cc: @creunabo
