### PR TITLE
Blacklist mmjd-gulp-este

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -1,4 +1,5 @@
 {
+  "mmjd-gulp-este": "duplicate of gulp-este",
   "gulp-blink": "deprecated. use `blink` instead.",
   "gulp-clean": "use the `del` module",
   "gulp-rimraf": "use the `del` module",


### PR DESCRIPTION
This plugin states it's a 'modified version' of `gulp-este`, but seems like nothing is really changed.

Take a look at the commit log: https://github.com/mmjd/mmjd-gulp-este/commits/master, as you see nothing is really changed.
