### PR TITLE
Blacklist gulp-minify-inline-scripts

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -58,6 +58,7 @@
   "gulp-pancakes": "does nothing",
   "gulp-batch-replace": "duplicate of gulp-replace",
   "gulp-mversion": "duplicate of gulp-bump",
+  "gulp-minify-inline-scripts": "duplicate of gulp-uglify-inline",
   "gulp-jshint-cached": "duplicate of gulp-jshint",
   "gulp-twitter": "not a gulp plugin",
   "gulp-print": "duplicate of gulp-debug",


### PR DESCRIPTION
Duplicate of gulp-uglify-inline. This plugin uses uglifyjs too (https://github.com/hellopao/gulp_plugin/blob/master/gulp-minify-inline-scripts/index.js#L5), and the other one was earlier.
