### PR TITLE
Blacklist gulp-karma

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -246,5 +246,6 @@
   "gulp-filter-by": "duplicate of gulp-filter",
   "gulp-inline-source": "duplicate of gulp-smoosher",
   "grunt-favicons-tasks": "use the `favicons` module directly",
-  "gulp-traceur-compiler": "duplicate of gulp-traceur"
+  "gulp-traceur-compiler": "duplicate of gulp-traceur",
+  "gulp-karma": "use `karma` directly (see https://github.com/karma-runner/gulp-karma)"
 }


### PR DESCRIPTION
https://github.com/lazd/gulp-karma isn't a real plugin as it doesn't process any files. 
It has some fundamental design issues (https://github.com/lazd/gulp-karma/issues/33) 
and doesn't bring enough value as Karma can be invoked directly 
(see https://github.com/karma-runner/gulp-karma)