### PR TITLE
Blacklist gulp-es6to5

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -21,6 +21,7 @@
   "gulp-image-optimization": "duplicate of gulp-imagemin",
   "gulp-bower": "use the bower module directly",
   "gulp-ember-handlebars": "duplicate of gulp-handlebars & too complex",
+  "gulp-es6to5": "duplicate of gulp-6to5",
   "gulp-handlebars-michael": "duplicate of gulp-handlebars",
   "gulpify": "deprecated - use vinyl-source-stream instead",
   "gulp-web-modules": "a grab bag of tasks/plugins - not a plugin itself",


### PR DESCRIPTION
Duplicate of [gulp-6to5](https://www.npmjs.com/package/gulp-6to5/).