### PR TITLE
Add `gulp-6to5` to the blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -252,5 +252,6 @@
   "gulp-lodash-template": "duplicate of gulp-template",
   "gulp-template-compile": "duplicate of gulp-template",
   "gulp-lodash-jst": "duplicate of gulp-template",
-  "gulp-tmpl": "duplicate of gulp-template"
+  "gulp-tmpl": "duplicate of gulp-template",
+  "gulp-6to5": "deprecated in favor of gulp-babel"
 }


### PR DESCRIPTION
As suggested by @phated in https://github.com/gulpjs/plugins/pull/158#issuecomment-74567144.