### PR TITLE
Blacklist `gulp-css-combo`

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -197,6 +197,7 @@
   "gulp-concat-coffee": "unpublished by author",
   "gulp-compass": "not a gulp plugin",
   "gulp-concat-sourcemap": "gulp-concat supports source maps",
+  "gulp-css-combo": "not a gulp plugin",
   "gulp-base64": "duplicate of gulp-css-base64",
   "gulp-download-atom-shell": "not a gulp plugin",
   "gulp-dummy-json": "not a gulp plugin",


### PR DESCRIPTION
This plugin is in many ways against our guidelines:

* It doesn't provide real documentation.

* It doesn't have any tests. (well technically it has, but https://github.com/daxingplay/gulp-css-combo/blob/master/test.js)

* It basically does nothing :) It's still an exact copy of `gulp-plugin-boilerplate`, tho it's published to npm.