### PR TITLE
Blacklist `gulp-ember-handlebarz`

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -21,6 +21,7 @@
   "gulp-image-optimization": "duplicate of gulp-imagemin",
   "gulp-bower": "use the bower module directly",
   "gulp-ember-handlebars": "duplicate of gulp-handlebars & too complex",
+  "gulp-ember-handlebarz": "duplicate of gulp-handlebars & too complex",
   "gulp-es6to5": "duplicate of gulp-6to5",
   "gulp-handlebars-michael": "duplicate of gulp-handlebars",
   "gulpify": "deprecated - use vinyl-source-stream instead",


### PR DESCRIPTION
The `gulp-ember-handlebars` plugin was blocked because it's `duplicate of gulp-handlebars & too complex`, so this one needs to be blacklisted too. `gulp-ember-handlebarz` is a fork of `gulp-ember-handlebars` but nothing actually changed.