### PR TITLE
Blacklist `gulp-git-pages`

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -80,6 +80,7 @@
   "gulp-saxon": "reads from fs and not stream",
   "gulp-gitinfo": "not a gulp plugin",
   "gulp-gh-pages-ci-compatible": "duplicate of gulp-gh-pages",
+  "gulp-git-pages": "duplicate of gulp-gh-pages",
   "gulp-clean-old": "duplicate of gulp-clean",
   "gulp-closure-compiler-old": "duplicate of gulp-closure-compiler",
   "gulp-changed-old": "duplicate of gulp-changed",


### PR DESCRIPTION
duplicate of `gulp-gh-pages`.