### PR TITLE
Blacklist gulp-build-branch

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -2,6 +2,7 @@
   "gulp-angular-templatecache-ionic": "duplicate of gulp-angular-templatecache",
   "mmjd-gulp-este": "duplicate of gulp-este",
   "gulp-blink": "deprecated. use `blink` instead.",
+  "gulp-build-branch": "use the `buildbrach` module",
   "gulp-clean": "use the `del` module",
   "gulp-rimraf": "use the `del` module",
   "gulp-browserify": "use the browserify module directly",


### PR DESCRIPTION
People can perfectly use the `buildbranch` module directly. The module even provides documentation on how to use it directly: https://github.com/nfroidure/buildbranch#build-system.