### PR TITLE
blacklist `gulp-concat-json2`

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -260,5 +260,6 @@
   "gulp-tmpl": "duplicate of gulp-template",
   "gulp-6to5": "deprecated in favor of gulp-babel",
   "gulp-jest": "use the `jest` module directly",
-  "gulp-karma": "use the `karma` module directly"
+  "gulp-karma": "use the `karma` module directly",
+  "gulp-concat-json2": "duplicate of gulp-concat-json, missing documentation"
 }


### PR DESCRIPTION
duplicate of gulp-concat-json, missing documentation