### PR TITLE
Add gulp-origin-stylus to the blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -263,5 +263,6 @@
   "gulp-jest": "use the `jest` module directly",
   "gulp-karma": "use the `karma` module directly",
   "gulp-concat-json2": "duplicate of gulp-concat-json, missing documentation",
-  "gulp-jscs-custom": "duplicate of gulp-jscs"
+  "gulp-jscs-custom": "duplicate of gulp-jscs",
+  "gulp-origin-stylus": "duplicate of gulp-stylus"
 }


### PR DESCRIPTION
`gulp-origin-stylus` https://www.npmjs.com/package/gulp-origin-stylus is a duplicate of `gulp-stylus`

