### PR TITLE
Blacklist `gulp-handlebars-compiler`

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -265,5 +265,6 @@
   "gulp-karma": "use the `karma` module directly",
   "gulp-concat-json2": "duplicate of gulp-concat-json, missing documentation",
   "gulp-jscs-custom": "duplicate of gulp-jscs",
-  "gulp-origin-stylus": "duplicate of gulp-stylus"
+  "gulp-origin-stylus": "duplicate of gulp-stylus",
+  "gulp-handlebars-compiler": "missing documentation, does basically nothing"
 }


### PR DESCRIPTION
This plugin's source code [is totally empty](https://github.com/pasangsherpa/gulp-handlebars-compiler/blob/master/index.js), although it's published to npm. I will create an issue in its repo.