### PR TITLE
blacklisted gulp-merge

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -266,5 +266,6 @@
   "gulp-jscs-custom": "duplicate of gulp-jscs",
   "gulp-origin-stylus": "duplicate of gulp-stylus",
   "gulp-handlebars-compiler": "missing documentation, does basically nothing",
-  "daguike-gulp-rev-del": "duplicate of rev-del"
+  "daguike-gulp-rev-del": "duplicate of rev-del",
+  "gulp-merge": "use `merge2` instead"
 }


### PR DESCRIPTION
I saw on StackOverflow that most answers use `gulp-merge` to create stream arrays instead of the recommended and "recipe-ed" `merge-stream` module. Might be worth blacklisting it.