### PR TITLE
Gulpfile: fix syntax error

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -48,7 +48,7 @@ gulp.task('assets', ['clean'], function () {
     'src/blackList.json',
     'src/favicon.ico',
     'src/logo.svg',
-    'src/opensearch.xml'
+    'src/opensearch.xml',
     'src/README.md'
   ], {base: 'src'})
     .pipe(gulp.dest('dist'))


### PR DESCRIPTION
Introduced in https://github.com/gulpjs/plugins/commit/10898426ed641c4c903278c9067aaf3680e8f356.