### PR TITLE
Added gulp-casperjs to blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -266,5 +266,6 @@
   "gulp-jscs-custom": "duplicate of gulp-jscs",
   "gulp-origin-stylus": "duplicate of gulp-stylus",
   "gulp-handlebars-compiler": "missing documentation, does basically nothing",
-  "daguike-gulp-rev-del": "duplicate of rev-del"
+  "daguike-gulp-rev-del": "duplicate of rev-del",
+  "gulp-casperjs": "not a gulp plugin"
 }


### PR DESCRIPTION
Calling gulp from node is [already a hack](http://macr.ae/article/gulp-casperjs.html), this plugin just seems to be wrapping it in a gulp plugin.

https://github.com/NullRefExcep/gulp-casperjs/blob/master/index.js#L40-L47

I'm pretty sure this shouldn't be a gulp plugin.

Also, isn't it duplicating every file? [here](https://github.com/NullRefExcep/gulp-casperjs/blob/master/index.js#L32-L34)