### PR TITLE
Add various typescript plugins to blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -266,5 +266,10 @@
   "gulp-origin-stylus": "duplicate of gulp-stylus",
   "gulp-handlebars-compiler": "missing documentation, does basically nothing",
   "daguike-gulp-rev-del": "duplicate of rev-del",
-  "gulp-casperjs": "not a gulp plugin"
+  "gulp-casperjs": "not a gulp plugin",
+  "gulp-tsb": "duplicate of gulp-typescript",
+  "gulp-tsc-sushicutta": "duplicate of gulp-typescript",
+  "gulp-type": "renamed to gulp-typescript",
+  "gulp-typescript-alpha-1.5.0": "duplicate of gulp-typescript",
+  "gulp-typescript-package": "use gulp-typescript, gulp-uglify and gulp.dest"
 }


### PR DESCRIPTION
I saw there were a lot typescript plugins on the registry, a big part of them are duplicates of `gulp-typescript`:

- `gulp-tsb` provides the same functionality as `gulp-typescript`
- `gulp-tsc-sushicutta` is a clone of `gulp-tsc` which is a duplicate of `gulp-typescript`
- `gulp-type` has been renamed to `gulp-typescript`
- `gulp-typescript-alpha-1.5.0` is a clone of `gulp-typescript`, only with a default of a setting changed
- `gulp-typescript-package` is a plugin that compiles and uglifies typescript files, which can easily be done using `gulp-typescript`, `gulp-uglify` & `gulp.dest`.