### PR TITLE
Blacklist gulp-electron

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -272,5 +272,6 @@
   "gulp-tsc-sushicutta": "duplicate of gulp-typescript",
   "gulp-type": "renamed to gulp-typescript",
   "gulp-typescript-alpha-1.5.0": "duplicate of gulp-typescript",
-  "gulp-typescript-package": "use gulp-typescript, gulp-uglify and gulp.dest"
+  "gulp-typescript-package": "use gulp-typescript, gulp-uglify and gulp.dest",
+  "gulp-electron": "not a gulp plugin"
 }


### PR DESCRIPTION
This plugin does not uses the stream API.