### PR TITLE
Blacklist `gulp-babel-transpiler`

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -273,5 +273,6 @@
   "gulp-type": "renamed to gulp-typescript",
   "gulp-typescript-alpha-1.5.0": "duplicate of gulp-typescript",
   "gulp-typescript-package": "use gulp-typescript, gulp-uglify and gulp.dest",
-  "gulp-electron": "not a gulp plugin"
+  "gulp-electron": "not a gulp plugin",
+  "gulp-babel-transpiler": "duplicate of gulp-babel"
 }


### PR DESCRIPTION
As it's a dupe of https://www.npmjs.com/package/gulp-babel/.  I have no idea how to notify
the creator as the plugin is not open source it seems.