### PR TITLE
Blacklist gulp-props2json

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -274,5 +274,7 @@
   "gulp-typescript-alpha-1.5.0": "duplicate of gulp-typescript",
   "gulp-typescript-package": "use gulp-typescript, gulp-uglify and gulp.dest",
   "gulp-electron": "not a gulp plugin",
+  "gulp-props2json": "duplicate of gulp-props",
+  "gulp-properties": "not a gulp plugin",
   "gulp-babel-transpiler": "duplicate of gulp-babel"
 }


### PR DESCRIPTION
Flagrant duplicate of an existing plugin.

- The real thing: https://github.com/crissdev/gulp-props
- Duplicate: https://github.com/ValeryIvanov/gulp-props2json

You may also consider to blacklist [gulp-properties](https://www.npmjs.com/package/gulp-properties) which is an empty package for quite a while.

Thanks.