### PR TITLE
Blacklist gulp-autoprefixer

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -276,5 +276,6 @@
   "gulp-electron": "not a gulp plugin",
   "gulp-props2json": "duplicate of gulp-props",
   "gulp-properties": "not a gulp plugin",
-  "gulp-babel-transpiler": "duplicate of gulp-babel"
+  "gulp-babel-transpiler": "duplicate of gulp-babel",
+  "gulp-autoprefixer": "use gulp-postcss with autoprefixer-core instead"
 }


### PR DESCRIPTION
I don't think there's any point in using gulp-autoprefixer since Autoprefixer became a PostCSS plugin. When you're using gulp-postcss, you can easily add other plugins as well (along with [autoprefixer-core](https://github.com/postcss/autoprefixer-core)).