### PR TITLE
Bumped gulp-autoprefixer. Added line spacing between tags and lightened font color.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "bower": "^1.3.12",
     "event-stream": "^3.2.2",
     "gulp": "^3.8.11",
-    "gulp-autoprefixer": "2.1.0",
+    "gulp-autoprefixer": "3.1.0",
     "gulp-gh-pages": "^0.4.0",
     "gulp-if": "^1.2.5",
     "gulp-livereload": "^3.8.0",

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -135,8 +135,9 @@ html, body {
     padding-right: 8px;
     padding-left: 8px;
     margin-right: 5px;
+    margin-top: 5px;
     font-size: 12px;
-    color: #333;
+    color: #66696A;
 }
 
 .tags a:hover {


### PR DESCRIPTION
Updated `gulp-autoprefixer` to latest version because of deprecation warning. 
Added line spacing to tags. 
Changed tag color to match the logo color which is slightly lighter than it was. 
Changes were made as per this issue https://github.com/gulpjs/plugins/issues/119