### PR TITLE
Add gulp.livereload to blacklist

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -278,5 +278,6 @@
   "gulp-uglifyjs-wrapper": "duplicate of gulp-uglify",
   "gulp-rollup": "use the `rollup` module directly",
   "gulp-livereload": "abandoned. use gulp-refresh",
-  "gulp-minify-css": "deprecated. use gulp-cssnano."
+  "gulp-minify-css": "deprecated. use gulp-cssnano.",
+  "gulp.livereload": "not maintained anymore. use gulp-refresh"
 }


### PR DESCRIPTION
<img width="534" alt="screen shot 2016-02-25 at 12 39 17" src="https://cloud.githubusercontent.com/assets/6170607/13318742/d32c2970-dbbc-11e5-9f8d-870893f520bd.png">

The package now also contains a deprecation message that suggests the use of gulp-refresh.