### PR TITLE
Unblacklist gulp-rollup

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -275,7 +275,6 @@
   "gulp-properties": "not a gulp plugin",
   "gulp-babel-transpiler": "duplicate of gulp-babel",
   "gulp-uglifyjs-wrapper": "duplicate of gulp-uglify",
-  "gulp-rollup": "use the `rollup` module directly",
   "gulp-livereload": "abandoned. use gulp-refresh",
   "gulp-minify-css": "deprecated. use gulp-clean-css.",
   "gulp.livereload": "not maintained anymore. use gulp-refresh",


### PR DESCRIPTION
With the release of [gulp-rollup](https://github.com/mcasimir/gulp-rollup) v2, this plugin no longer breaks the guidelines as far as I know. It will only read from the filesystem if the user explicitly allows it through an option.