### PR TITLE
Blacklist gulp-better-rollup

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -278,5 +278,6 @@
   "gulp-minify-css": "deprecated. use gulp-clean-css.",
   "gulp.livereload": "not maintained anymore. use gulp-refresh",
   "gulp-cssnano": "use gulp-clean-css or cssnano with gulp-postcss",
-  "gulp-lodash-autobuild": "promotes anti-patterns, use child_process"
+  "gulp-lodash-autobuild": "promotes anti-patterns, use child_process",
+  "gulp-better-rollup": "use rollup-stream, gulp-rollup, or the `rollup` module directly"
 }


### PR DESCRIPTION
[This plugin reads from the filesystem directly, which is what the original gulp-rollup was blacklisted for.](https://github.com/MikeKovarik/gulp-better-rollup/issues/2) gulp-rollup still doesn't show up in the plugin search (has the blacklist not been updated?), but gulp-better-rollup does, and I'm not having it.