### PR TITLE
Blacklist gulp-static-site-generator

### DIFF
--- a/src/blackList.json
+++ b/src/blackList.json
@@ -280,5 +280,6 @@
   "gulp-cssnano": "use gulp-clean-css or cssnano with gulp-postcss",
   "gulp-lodash-autobuild": "promotes anti-patterns, use child_process",
   "gulp-better-rollup": "use rollup-stream, gulp-rollup, or the `rollup` module directly",
-  "@absolunet/gulp-include": "fork of gulp-include, use the original module"
+  "@absolunet/gulp-include": "fork of gulp-include, use the original module",
+  "gulp-static-site-generator": "does too much"
 }


### PR DESCRIPTION
I've written a project, https://github.com/straticjs, that will do the same thing but in an idiomatic gulp way (the project consists of many modules and a Yeoman generator). I'm reluctant to suggest it as a replacement in this blacklist entry for fear of being too opinionated, etc., but I'd be happy to change it if desired ;)