### PR TITLE
fix the build by adding the slide-header bower component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "jquery": "~2.1.0",
     "angular": "~1.2.11",
-    "ngInfiniteScroll": "~1.1.0"
+    "ngInfiniteScroll": "~1.1.0",
+    "smart-header": "slide-header#^1.0.1"
   },
   "overrides": {
     "angular": {

--- a/src/index.html
+++ b/src/index.html
@@ -52,8 +52,8 @@
         <script src="../bower_components/jquery/dist/jquery.js"></script>
         <script src="../bower_components/angular/angular.js"></script>
         <script src="../bower_components/ngInfiniteScroll/build/ng-infinite-scroll.js"></script>
-        <script src="../bower_components/slide-header/slide-header.js"></script>
-        <script src="../bower_components/slide-header/directive.js"></script>
+        <script src="../bower_components/smart-header/slide-header.js"></script>
+        <script src="../bower_components/smart-header/directive.js"></script>
         <!-- endbuild -->
 
         <!-- build:js js/app.js -->


### PR DESCRIPTION
Before, running `gulp` would fail. This seems to fix it.